### PR TITLE
[fix] kafka에서 받은 Alert 객체의 역직렬화가 가능하게끔 Alert에 @NoArgsConstructor 추가

### DIFF
--- a/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/entity/Alert.java
+++ b/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/entity/Alert.java
@@ -3,6 +3,7 @@ package com.kernelsquare.domainmongodb.domain.alert.entity;
 import io.micrometer.common.util.StringUtils;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -14,6 +15,7 @@ import java.util.Objects;
 
 @Getter
 @Document(collection = "alert")
+@NoArgsConstructor
 public class Alert {
     @Id
     private String id;


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #14 

## 개요
> kafka에서 받은 Alert 객체의 역직렬화가 가능하게끔 Alert에 @NoArgsConstructor 추가

## 상세 내용
- kafka에서 받은 Alert 객체의 역직렬화가 가능하게끔 Alert에 @NoArgsConstructor 추가
