### PR TITLE
fix: 채팅 카프카 컨슈머 설정 수정

### DIFF
--- a/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/KafkaConsumerConfig.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/KafkaConsumerConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.HashMap;
@@ -26,8 +27,10 @@ public class KafkaConsumerConfig {
 
 		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
 		config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+		config.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+		config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
 		config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
 		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
 

--- a/chatting-api/src/main/java/com/kernelsquare/chattingapi/common/config/KafkaConsumerConfig.java
+++ b/chatting-api/src/main/java/com/kernelsquare/chattingapi/common/config/KafkaConsumerConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.HashMap;
@@ -25,8 +26,12 @@ public class KafkaConsumerConfig {
 
 		config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, url);
 		config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+		config.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+		config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+		config.put(JsonDeserializer.TYPE_MAPPINGS,
+			"ChatMessageRequest:com.kernelsquare.chattingapi.domain.chatting.dto.ChatMessageRequest");
 		config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
 		config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #46 

## 개요
현재 채팅방 30분 만료 메시지를 member-api에서 카프카로 보내고 있는데, 이 때 카프카 메시지 헤더에 객체 클래스에 대한 정보가 들어있습니다.
그래서 chatting-api 서버의 카프카 컨슈머에서 member-api의 ChatMessageRequest와 같은 위치에서 ChatMessageRequest를 찾으려고 합니다.
하지만 member-api의 ChatMessageRequest와 chatting-api의 ChatMessageRequest 위치가 달라서 찾지못하고 역직렬화에 실패했다는 에러 로그를 출력하게 됩니다.
여기서 카프카의 기본 설정은 역직렬화에 실패한 메시지를 빠른 속도로 다시 역직렬화 시도를 하여 무한루프에 빠지게 됩니다.
그로인해 엄청나게 빠른 속도로 로그가 쌓이고 디스크 공간이 모자르게 됩니다.

## 상세 내용
- 들어오는 ChatMessageRequest는 chatting-api의 ChatMessageRequest의 위치로 매핑 시킴
- 만약에 역직렬화에 실패하면 해당 메시지는 무시하고 다음 메시지로 넘어가게 구성

