### PR TITLE
[bugfix] rest docs의 alert-api-index.adoc 에서 모든 개인 알림 조회 URL 오타 수정

### DIFF
--- a/alert-api/src/docs/asciidoc/alert-api-index.adoc
+++ b/alert-api/src/docs/asciidoc/alert-api-index.adoc
@@ -21,5 +21,5 @@ endif::[]
 |===
 |이름 |Http Method |API Endpoint
 |link:alert-subscribe.html[SSE 연결] |GET |/api/v1/alerts/sse
-|link:alert-all-found.html[모든 개인 알림 조회] |GET |/api/v1/coding-meeting-comments/{codingMeetingToken}
+|link:alert-all-found.html[모든 개인 알림 조회] |GET |/api/v1/alerts
 


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #48 

## 개요
> rest docs의 alert-api-index.adoc 에서 모든 개인 알림 조회 URL 오타를 수정하기 위함

## 상세 내용
- alert-api-index.adoc파일에서 모든 개인 알림 조회 URL  /api/v1/coding-meeting-comments/{codingMeetingToken -> /api/v1/alerts로 수정
