### PR TITLE
[refactor] 알림 메시지 데이터 구조 변경

### DIFF
--- a/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/SecurityConfig.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
 		"/actuator",
 		"/actuator/**",
 		"/docs/**",
+		"/environment",
 	};
 
 	private final String[] hasAnyAuthorityPatterns = new String[] {

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/common/server/SeverController.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/common/server/SeverController.java
@@ -1,0 +1,12 @@
+package com.kernelsquare.alertapi.common.server;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SeverController {
+    @GetMapping("/environment")
+    public String getEnv() {
+        return "alert";
+    }
+}

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/dto/AlertDto.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/dto/AlertDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class AlertDto {
     @Builder
@@ -15,7 +16,6 @@ public class AlertDto {
         String recipient,
         String senderId,
         String sender,
-        String message,
         Alert.AlertType alertType,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = TimeResponseFormat.PATTERN)
         LocalDateTime sendTime
@@ -23,12 +23,33 @@ public class AlertDto {
 
     @Builder
     public record PersonalFindAllResponse(
-        List<FindAllResponse> personalAlertList
+        List<AlertDto.MessageResponse> personalAlertList
     ) {
-        public static PersonalFindAllResponse from(List<FindAllResponse> personalAlert) {
+        public static PersonalFindAllResponse from(List<AlertDto.MessageResponse> personalAlert) {
             return new PersonalFindAllResponse(
                 personalAlert
             );
         }
     }
+
+    @Builder
+    public record MessageResponse(
+        String id,
+        Alert.AlertType alertType,
+        String recipient,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = TimeResponseFormat.PATTERN)
+        LocalDateTime sendTime,
+        Map<String, String> payload
+    ) {
+        public static MessageResponse from(Alert alert) {
+            return MessageResponse.builder()
+                .id(alert.getId())
+                .alertType(alert.getAlertType())
+                .recipient(alert.getRecipient())
+                .sendTime(alert.getSendTime())
+                .payload(alert.getPayload())
+                .build();
+        }
+    }
+
 }

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/facade/AlertFacade.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/facade/AlertFacade.java
@@ -1,6 +1,5 @@
 package com.kernelsquare.alertapi.domain.alert.facade;
 
-import com.kernelsquare.domainmongodb.domain.alert.info.AlertInfo;
 import com.kernelsquare.alertapi.domain.alert.dto.AlertDto;
 import com.kernelsquare.alertapi.domain.alert.mapper.AlertDtoMapper;
 import com.kernelsquare.alertapi.domain.alert.service.AlertService;
@@ -17,11 +16,7 @@ public class AlertFacade {
     private final AlertDtoMapper alertDtoMapper;
 
     public AlertDto.PersonalFindAllResponse findAllAlerts(MemberAdapter memberAdapter) {
-        List<AlertInfo> allAlertInfo = alertService.findAllAlerts(alertDtoMapper.toCommand(memberAdapter));
-
-        List<AlertDto.FindAllResponse> responseList = allAlertInfo.stream()
-            .map(alertDtoMapper::toFindAllResponse)
-            .toList();
+        List<AlertDto.MessageResponse> responseList = alertService.findAllAlerts(alertDtoMapper.toCommand(memberAdapter));
 
         return AlertDto.PersonalFindAllResponse.from(responseList);
     }

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
@@ -1,5 +1,6 @@
 package com.kernelsquare.alertapi.domain.alert.handler;
 
+import com.kernelsquare.alertapi.domain.alert.dto.AlertDto;
 import com.kernelsquare.domainmongodb.domain.alert.entity.Alert;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -40,12 +41,14 @@ public class SseEmitterHandler {
     public void sendEmitter(Alert alert) {
         SseEmitter emitter = getEmitter(Long.valueOf(alert.getRecipientId()));
 
+        AlertDto.MessageResponse data = AlertDto.MessageResponse.from(alert);
+
         if (Objects.nonNull(emitter)) {
             try {
                 emitter.send(SseEmitter.event()
-                    .id(alert.getRecipientId())
-                    .name(alert.getAlertType().name())
-                    .data(alert, MediaType.APPLICATION_JSON));
+                    .id(data.id())
+                    .name(data.alertType().name())
+                    .data(data, MediaType.APPLICATION_JSON));
             } catch (IOException e) {
                 deleteEmitter(Long.valueOf(alert.getRecipientId()));
                 emitter.completeWithError(e);

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/service/AlertService.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/service/AlertService.java
@@ -1,13 +1,13 @@
 package com.kernelsquare.alertapi.domain.alert.service;
 
+import com.kernelsquare.alertapi.domain.alert.dto.AlertDto;
 import com.kernelsquare.domainmongodb.domain.alert.command.AlertCommand;
 import com.kernelsquare.domainmongodb.domain.alert.entity.Alert;
-import com.kernelsquare.domainmongodb.domain.alert.info.AlertInfo;
 
 import java.util.List;
 
 public interface AlertService {
-    List<AlertInfo> findAllAlerts(AlertCommand.FindCommand command);
+    List<AlertDto.MessageResponse> findAllAlerts(AlertCommand.FindCommand command);
 
     void sendToClient(Alert alert);
 

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/service/AlertServiceImpl.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/service/AlertServiceImpl.java
@@ -1,9 +1,9 @@
 package com.kernelsquare.alertapi.domain.alert.service;
 
+import com.kernelsquare.alertapi.domain.alert.dto.AlertDto;
 import com.kernelsquare.alertapi.domain.alert.manager.SseManager;
 import com.kernelsquare.domainmongodb.domain.alert.command.AlertCommand;
 import com.kernelsquare.domainmongodb.domain.alert.entity.Alert;
-import com.kernelsquare.domainmongodb.domain.alert.info.AlertInfo;
 import com.kernelsquare.domainmongodb.domain.alert.repository.AlertReader;
 import com.kernelsquare.domainmongodb.domain.alert.repository.AlertStore;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +21,9 @@ public class AlertServiceImpl implements AlertService {
 
 
     @Override
-    public List<AlertInfo> findAllAlerts(AlertCommand.FindCommand command) {
+    public List<AlertDto.MessageResponse> findAllAlerts(AlertCommand.FindCommand command) {
         return alertReader.findAllAlerts(command.memberId()).stream()
-            .map(AlertInfo::of)
+            .map(AlertDto.MessageResponse::from)
             .toList();
     }
 

--- a/alert-api/src/test/java/com/kernelsquare/alertapi/domain/alert/controller/AlertControllerTest.java
+++ b/alert-api/src/test/java/com/kernelsquare/alertapi/domain/alert/controller/AlertControllerTest.java
@@ -6,11 +6,13 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -111,17 +113,19 @@ class AlertControllerTest extends RestDocsControllerTest {
 
 		MemberAdapter memberAdapter = new MemberAdapter(MemberAdaptorInstance.of(member));
 
-		AlertDto.FindAllResponse findAllResponse = AlertDto.FindAllResponse.builder()
-			.recipientId("1")
-			.recipient("시나모롤")
-			.senderId("2")
-			.sender("강형욱")
-			.message("므헷헷헷x999999")
+		AlertDto.MessageResponse findAllResponse = AlertDto.MessageResponse.builder()
+			.id("alt_y8fWs19jzJFhZwi4")
 			.alertType(Alert.AlertType.QUESTION_REPLY)
+			.recipient("시나모롤")
 			.sendTime(LocalDateTime.now())
+			.payload(Map.of(
+				"questionTitle", "관리자의 미덕",
+				"sender", "고김홍",
+				"questionId", "10"
+			))
 			.build();
 
-		List<AlertDto.FindAllResponse> findAllResponseList = List.of(findAllResponse);
+		List<AlertDto.MessageResponse> findAllResponseList = List.of(findAllResponse);
 
 		AlertDto.PersonalFindAllResponse response = AlertDto.PersonalFindAllResponse.from(findAllResponseList);
 
@@ -143,20 +147,20 @@ class AlertControllerTest extends RestDocsControllerTest {
 					fieldWithPath("data").type(JsonFieldType.OBJECT).description("데이터"),
 					fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 상태 코드"),
 					fieldWithPath("msg").type(JsonFieldType.STRING).description("응답 메시지"),
-					fieldWithPath("data.personal_alert_list[].recipient_id").type(JsonFieldType.STRING)
+					fieldWithPath("data.personal_alert_list[].id").type(JsonFieldType.STRING)
 						.description("알림 수신자 ID"),
-					fieldWithPath("data.personal_alert_list[].recipient").type(JsonFieldType.STRING)
-						.description("알림 수신자 닉네임"),
-					fieldWithPath("data.personal_alert_list[].sender_id").type(JsonFieldType.STRING)
-						.description("알림 송신자 ID"),
-					fieldWithPath("data.personal_alert_list[].sender").type(JsonFieldType.STRING)
-						.description("알림 송신자 닉네임"),
-					fieldWithPath("data.personal_alert_list[].message").type(JsonFieldType.STRING)
-						.description("알림 메시지"),
 					fieldWithPath("data.personal_alert_list[].alert_type").type(JsonFieldType.STRING)
 						.description("알림 타입"),
+					fieldWithPath("data.personal_alert_list[].recipient").type(JsonFieldType.STRING)
+						.description("알림 수신자 닉네임"),
 					fieldWithPath("data.personal_alert_list[].send_time").type(JsonFieldType.STRING)
-						.description("알림 보낸 시간")
+						.description("알림 보낸 시간"),
+					fieldWithPath("data.personal_alert_list[].payload.questionTitle").type(JsonFieldType.STRING)
+						.description("질문 답변 알림 - 질문 제목"),
+					fieldWithPath("data.personal_alert_list[].payload.sender").type(JsonFieldType.STRING)
+						.description("질문 답변 알림 - 답변 작성자"),
+					fieldWithPath("data.personal_alert_list[].payload.questionId").type(JsonFieldType.STRING)
+						.description("질문 답변 알림 - 질문 ID")
 				)));
 
 		//verify

--- a/domain-mongodb/build.gradle
+++ b/domain-mongodb/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+    implementation project(path: ':core')
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 

--- a/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/entity/Alert.java
+++ b/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/entity/Alert.java
@@ -1,21 +1,16 @@
 package com.kernelsquare.domainmongodb.domain.alert.entity;
 
-import io.micrometer.common.util.StringUtils;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.security.InvalidParameterException;
 import java.time.LocalDateTime;
-import java.util.Objects;
+import java.util.Map;
 
 @Getter
 @Document(collection = "alert")
-@NoArgsConstructor
 public class Alert {
     @Id
     private String id;
@@ -29,11 +24,11 @@ public class Alert {
 
     private String sender;
 
-    private String message;
-
     private AlertType alertType;
 
     private LocalDateTime sendTime;
+
+    private Map<String, String> payload;
 
     @Getter
     @RequiredArgsConstructor
@@ -41,29 +36,5 @@ public class Alert {
         QUESTION_REPLY,
         RANK_ANSWER,
         COFFEE_CHAT_REQUEST
-    }
-
-    @Builder
-    public Alert(String recipientId, String recipient, String senderId, String sender, String message, AlertType alertType) {
-        if (StringUtils.isBlank(recipientId))
-            throw new InvalidParameterException("Invalid recipientId");
-        if (StringUtils.isBlank(recipient))
-            throw new InvalidParameterException("Invalid recipient");
-        if (StringUtils.isBlank(senderId))
-            throw new InvalidParameterException("Invalid senderId");
-        if (StringUtils.isBlank(sender))
-            throw new InvalidParameterException("Invalid sender");
-        if (StringUtils.isBlank(message))
-            throw new InvalidParameterException("Invalid message");
-        if (Objects.isNull(alertType))
-            throw new InvalidParameterException("Invalid AlertType");
-
-        this.recipientId = recipientId;
-        this.recipient = recipient;
-        this.senderId = senderId;
-        this.sender = sender;
-        this.message = message;
-        this.alertType = alertType;
-        this.sendTime = LocalDateTime.now();
     }
 }

--- a/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/info/AlertInfo.java
+++ b/domain-mongodb/src/main/java/com/kernelsquare/domainmongodb/domain/alert/info/AlertInfo.java
@@ -12,7 +12,6 @@ public class AlertInfo {
     private final String recipient;
     private final String senderId;
     private final String sender;
-    private final String message;
     private final Alert.AlertType alertType;
     private final LocalDateTime sendTime;
 
@@ -22,7 +21,6 @@ public class AlertInfo {
         this.recipient = alert.getRecipient();
         this.senderId = alert.getSenderId();
         this.sender = alert.getSender();
-        this.message = alert.getMessage();
         this.alertType = alert.getAlertType();
         this.sendTime = alert.getSendTime();
     }


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #51 

## 개요
> 화면에 뿌리는데 필요한 데이터는 넣고 불필요한 데이터는 빼고 응답으로 주기 위함

## 상세 내용
- AlertMessage는 메시지의 멤버 변수는 공통으로 사용하는 것이고 payload는 해당 메시지에만 사용하는 데이터를 넣는 형태로 구현
- MessageResponse가 dto인지 info인지 모호함 부분이 있음(저는 dto로 두었습니다.)