### PR TITLE
[refactor] sse 생성할 때 연결 확인이라는 sse 메시지를 보내도록 수정

### DIFF
--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
@@ -34,6 +34,18 @@ public class SseEmitterHandler {
 
         emitter.onCompletion(() -> deleteEmitter(memberId));
         emitter.onTimeout(emitter::complete);
+        emitter.onError(e -> emitter.complete());
+
+        if (Objects.nonNull(emitter)) {
+            try {
+                emitter.send(SseEmitter.event()
+                    .name("연결 확인")
+                    .data("연결 확인", MediaType.APPLICATION_JSON));
+            } catch (IOException e) {
+                deleteEmitter(memberId);
+                emitter.completeWithError(e);
+            }
+        }
 
         return emitter;
     }


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #54 

## 개요
> sse 생성할 때 연결 확인이라는 sse 메시지를 클라이언트에게 보내도록 로직을 수정하기 위함

## 상세 내용
- SseEmitterHandler파일의 createEmitter 메서드에서 emitter를 return 하기전에 send를 하여 구독이 되면 연결 확인 메시지를 받을 수 있게 수정
