### PR TITLE
[refactor] alert, chatting, admin 도메인 CorsConfig 파일의 allowedOrigins 변경

### DIFF
--- a/admin-api/src/main/java/com/kernelsquare/adminapi/common/config/CorsConfig.java
+++ b/admin-api/src/main/java/com/kernelsquare/adminapi/common/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig implements WebMvcConfigurer {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("https://kernelsquare.live", "http://localhost:3000")
+					.allowedOrigins("https://kernelsquare.live", "http://dev.kernelsquare.live", "http://admin.kernelsquare.live", "http://localhost:3000")
 					.allowCredentials(true)
 					.allowedHeaders("*")
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/CorsConfig.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig implements WebMvcConfigurer {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("https://kernelsquare.live", "http://localhost:3000")
+					.allowedOrigins("https://kernelsquare.live", "http://dev.kernelsquare.live", "http://admin.kernelsquare.live", "http://localhost:3000")
 					.allowCredentials(true)
 					.allowedHeaders("*")
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")

--- a/chatting-api/src/main/java/com/kernelsquare/chattingapi/common/config/CorsConfig.java
+++ b/chatting-api/src/main/java/com/kernelsquare/chattingapi/common/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig implements WebMvcConfigurer {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-					.allowedOrigins("https://kernelsquare.live", "http://localhost:3000")
+					.allowedOrigins("https://kernelsquare.live", "http://dev.kernelsquare.live", "http://admin.kernelsquare.live", "http://localhost:3000")
 					.allowCredentials(true)
 					.allowedHeaders("*")
 					.allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH")


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #60 

## 개요
> dev 환경과 어드민 환경에서도 사용할 수 있게끔 하기 위함

## 상세 내용
- alert, chatting, admin 도메인 CorsConfig 파일의 allowedOrigins 변경
