### PR TITLE
[refactor] 같은 SseEmitter로 사용할 수 있게끔 관련 로직 수정

### DIFF
--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
@@ -40,7 +40,8 @@ public class SseEmitterHandler {
             try {
                 emitter.send(SseEmitter.event()
                     .name("연결 확인")
-                    .data("연결 확인", MediaType.APPLICATION_JSON));
+                    .data("연결 확인", MediaType.APPLICATION_JSON)
+                    .reconnectTime(5000L));
             } catch (IOException e) {
                 deleteEmitter(memberId);
                 emitter.completeWithError(e);

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
@@ -40,7 +40,8 @@ public class SseEmitterHandler {
             try {
                 emitter.send(SseEmitter.event()
                     .name("연결 확인")
-                    .data("연결 확인", MediaType.APPLICATION_JSON));
+                    .data("연결 확인", MediaType.APPLICATION_JSON)
+                    .reconnectTime(10000L));
             } catch (IOException e) {
                 deleteEmitter(memberId);
                 emitter.completeWithError(e);

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
@@ -40,8 +40,7 @@ public class SseEmitterHandler {
             try {
                 emitter.send(SseEmitter.event()
                     .name("연결 확인")
-                    .data("연결 확인", MediaType.APPLICATION_JSON)
-                    .reconnectTime(10000L));
+                    .data("연결 확인", MediaType.APPLICATION_JSON));
             } catch (IOException e) {
                 deleteEmitter(memberId);
                 emitter.completeWithError(e);


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [ ] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #63 

## 개요
> emitter에 reconnectTime 추가하여 재연결을 5초동안 기다리게 설정

## 상세 내용
- chatGPT 왈 reconnectTime 동안 재연결을 성공하면 이전에 사용한 SseEmitter를 사용한다고 함
- 개발용 알림 서버가 없기에 main에 머지가 되어야 의도한대로 동작하는지 확인할 수 있음
