### PR TITLE
[fix] scheduler 기능을 사용해서 하트비트 전송

### DIFF
--- a/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/SchedulingConfig.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.kernelsquare.alertapi.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/SecurityConfig.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/common/config/SecurityConfig.java
@@ -32,10 +32,11 @@ public class SecurityConfig {
 		"/actuator/**",
 		"/docs/**",
 		"/environment",
+		"/api/v1/alerts/**",
 	};
 
 	private final String[] hasAnyAuthorityPatterns = new String[] {
-		"/api/v1/alerts/**",
+//		"/api/v1/alerts/**",
 	};
 
 	@Bean
@@ -54,7 +55,7 @@ public class SecurityConfig {
 			.requestMatchers(HttpMethod.GET, "/api/v1/test").permitAll()
 
 			// 모든 권한에 대한 접근 허용
-			.requestMatchers(hasAnyAuthorityPatterns).authenticated()
+//			.requestMatchers(hasAnyAuthorityPatterns).authenticated()
 		);
 
 		http.addFilterBefore(new JWTSettingFilter(tokenProvider), BasicAuthenticationFilter.class);

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/handler/SseEmitterHandler.java
@@ -28,7 +28,7 @@ public class SseEmitterHandler {
     }
 
     public SseEmitter createEmitter(Long memberId) {
-        SseEmitter emitter = new SseEmitter(60000L);
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
 
         addEmitter(memberId, emitter);
 

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/manager/AlertSchedulerManager.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/manager/AlertSchedulerManager.java
@@ -1,0 +1,5 @@
+package com.kernelsquare.alertapi.domain.alert.manager;
+
+public interface AlertSchedulerManager {
+    void sendHeartbeat();
+}

--- a/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/manager/AlertSchedulerManagerImpl.java
+++ b/alert-api/src/main/java/com/kernelsquare/alertapi/domain/alert/manager/AlertSchedulerManagerImpl.java
@@ -1,0 +1,36 @@
+package com.kernelsquare.alertapi.domain.alert.manager;
+
+import com.kernelsquare.alertapi.domain.alert.handler.SseEmitterHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequiredArgsConstructor
+public class AlertSchedulerManagerImpl implements AlertSchedulerManager {
+    private final SseEmitterHandler sseEmitterHandler;
+
+    @Override
+    @Scheduled(fixedDelay = 40000)
+    public void sendHeartbeat() {
+        ConcurrentHashMap<Long, SseEmitter> emitters = sseEmitterHandler.getEmitters();
+        // 모든 연결된 SseEmitter에게 빈 메시지를 보냄
+        for (Map.Entry<Long, SseEmitter> entry : emitters.entrySet()) {
+            SseEmitter emitter = entry.getValue();
+            try {
+                emitter.send(SseEmitter.event()
+                    .name("연결 확인")
+                    .data("연결 확인", MediaType.APPLICATION_JSON));
+            } catch (IOException e) {
+                // 에러가 발생하면 해당 emitter를 제거
+                sseEmitterHandler.deleteEmitter(entry.getKey());
+            }
+        }
+    }
+}

--- a/alert-api/src/main/resources/application.yml
+++ b/alert-api/src/main/resources/application.yml
@@ -22,8 +22,8 @@ spring:
         show_sql: true
 
     database: mysql
-
     database-platform: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
 
   security:
     jwt:


### PR DESCRIPTION
## PR을 보내기 전에 확인해주세요!!
- [x] 컨벤션에 맞게 작성했습니다. 컨벤션 확인은 [여기](https://www.notion.so/3ab6391203024ffa8be3b414c511d60e?pvs=4)
- [x] 변경 사항에 대한 테스트를 했습니다.

## 관련 이슈
close: #66 

## 개요
> 클라이언트에서 설정한 하트비트 타임 아웃 시간이 지나서 activirty error가 나기전에 하트비트를 보내 기존 SseEmitter를 아용할 수 있게 스케줄러를 구현하기 위함

## 상세 내용
- AlertSchedulerManagerImpl에서 서버가 시작된 시간을 기준으로 40초마다 연결 되어있는 모든 SseEmitter에 연결 확인 메시지를 보내도록 구현
- 서버에서 설정한 SseEmitter 타임 아웃 시간이 지나면 클라이언트에서 다시 재연결을 시도하는데, SecurityConfig에서 "/api/v1/alerts/**"를 hasAnyAuthorityPatterns에 두면 정상 동작은 하지만 권한 관련 error 로그가 많이 찍혀서 permitAllPatterns에 두어 warn 로그 한번만 찍히게 함
- SSE통신하는 동안 Http Connection이 열려있기 때문에 subscribe api 과정에서 JPA를 사용한다면 DB Connection도 계속 열려있기 때문에 open-in-view: false를 설정하여 DB Connection을 닫도록 함
- 의도한 동작을 하지 않았던 reconnectionTime 제거
